### PR TITLE
change url to relative links and add rule descriptions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ You can configure rules in 2 ways:
 
 ## Supported Rules
 
-- [hof-name-prefix](https://github.com/timon-and-pumbaa/eslint-plugin-fsd/blob/master/docs/rules/hof-name-prefix.md) 2 in functionsNaming
-- [jq-use-js-prefix-in-selector](https://github.com/timon-and-pumbaa/eslint-plugin-fsd/blob/master/docs/rules/jq-use-js-prefix-in-selector.md) 1 in jQuery
-- [jq-cache-dom-elements](https://github.com/timon-and-pumbaa/eslint-plugin-fsd/blob/master/docs/rules/jq-cache-dom-elements.md) 2 in jQuery
-- [split-conditionals](https://github.com/timon-and-pumbaa/eslint-plugin-fsd/blob/master/docs/rules/split-conditionals.md) 7 in goodPractice
-- [no-heavy-constructor](https://github.com/timon-and-pumbaa/eslint-plugin-fsd/blob/master/docs/rules/no-heavy-constructor.md) 10 in goodPractice
-- [no-function-declaration-in-event-listener](https://github.com/timon-and-pumbaa/eslint-plugin-fsd/blob/master/docs/rules/no-function-declaration-in-event-listener.md) 11 in goodPractice
+- [hof-name-prefix](docs/rules/hof-name-prefix.md) - *enforce `make` prefix in higher order function names*
+- [jq-use-js-prefix-in-selector](docs/rules/jq-use-js-prefix-in-selector.md) - *enforce `js-` prefix in classes that are used to search the DOM*
+- [jq-cache-dom-elements](docs/rules/jq-cache-dom-elements.md) - *enforce caching of all found DOM elements*
+- [split-conditionals](docs/rules/split-conditionals.md) - *disallow complex conditions*
+- [no-heavy-constructor](docs/rules/no-heavy-constructor.md) - *disallow searching the DOM tree and defining handlers in the constructor*
+- [no-function-declaration-in-event-listener](docs/rules/no-function-declaration-in-event-listener.md) - *enforce moving event handlers to separate functions*

--- a/docs/rules/jq-cache-dom-elements.md
+++ b/docs/rules/jq-cache-dom-elements.md
@@ -1,6 +1,6 @@
 # Cache all selected DOM elements (jq-cache-dom-elements)
 
-All found items need to be cached.
+All found DOM elements need to be cached.
 
 ## Rule Details
 


### PR DESCRIPTION
Ром, добавил относительные ссылки на доки правил, и в readme добавил краткое описание вместо очень неявных отсылок к стандартам (к тому же ссылки на стандарты есть в доках правил).